### PR TITLE
chore: hygiene sweep — add authors to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,6 +2,11 @@ cff-version: 1.2.0
 type: software
 title: csl-app
 message: If you use this software, please cite it.
+authors:
+  - family-names: Patel
+    given-names: Dhaval
+  - family-names: Gasūns
+    given-names: Mārcis
 license: GPL-3.0
 repository-code: https://github.com/sanskrit-lexicon/csl-app
 keywords:


### PR DESCRIPTION
## Hygiene sweep

A planned hygiene sweep for `csl-app`. Two of the originally planned items were already resolved upstream, so this PR contains only the remaining substantive fix.

### What changed
- **`CITATION.cff`** — added the missing `authors:` field. The file already existed on `main` but had no authors, which CFF 1.2.0 requires for a valid, citable software record. Authors are the top human contributors by commit count (`git shortlog -sne`), bots excluded:
  - Dhaval Patel (178 commits)
  - Mārcis Gasūns (10 commits)

### Skipped (already resolved / not applicable)
- **Untrack `.ai_state.md`** — the file is **not present on `origin/main`** (the only copy was an unpushed local `ai-wip` commit), so there is nothing to untrack. `.gitignore` left unchanged.
- **Create `CITATION.cff`** — the file **already exists** on `main`; rather than re-create it, this PR completes it with the required authors field.

No ORCIDs invented. No BOM. CodeQL / deploy / Dependabot untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
