### PR TITLE
fix: strip SLP1 accent markers when Vedic Accents is off

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,0 +1,19 @@
+# Project Objective: [Global Goal]
+
+<!-- Replace the bracket above with the current high-level goal for this session. -->
+
+## ➡️ Next Steps (Queue)
+
+- [ ] (none queued yet)
+
+## 🚧 Current Work-In-Progress (WIP)
+
+- [ ] (no active task)
+
+## 🧠 Dev Notes & Hypotheses
+
+<!-- Persistent bugs, architectural pivots, things future-you needs to know. Keep dated. -->
+
+## ✅ Completed (Recent only)
+
+<!-- Move items here as they're checked off. Trim aggressively — only the recent few. -->

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)",
+      "Bash(gh pr *)",
+      "PowerShell(gh pr *)",
+      "PowerShell(winget install *)",
+      "PowerShell(choco install *)",
+      "PowerShell(& \"$env:USERPROFILE\\\\gh-cli\\\\bin\\\\gh.exe\" pr list)",
+      "PowerShell(git checkout *)",
+      "PowerShell(git *)",
+      "PowerShell(& \"$env:USERPROFILE\\\\gh-cli\\\\bin\\\\gh.exe\" pr view 37)",
+      "PowerShell(& \"$env:USERPROFILE\\\\gh-cli\\\\bin\\\\gh.exe\" pr diff 37)"
+    ]
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,42 @@
+name: Bug
+description: A defect — wrong output, broken contract, regression.
+title: "[bug] "
+labels: ["bug", "minor"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What is broken?
+      description: Describe the unexpected behaviour or output.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run command X
+        2. Observe output Y
+        3. Expected Z
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, language version, relevant config.
+      placeholder: |
+        - OS: Windows 11 / Ubuntu 22.04
+        - Python/Node version
+        - Commit SHA
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - trivial — cosmetic, no functional impact
+        - minor — single function or component
+        - major — multiple files / breaks existing workflow
+        - critical — data loss, security, blocks all users
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussion / cross-repo question
+    url: https://github.com/sanskrit-lexicon/COLOGNE/issues
+    about: For project-wide discussions or questions that span multiple repos.
+  - name: Code of Conduct
+    url: https://github.com/sanskrit-lexicon/COLOGNE/blob/master/CONTRIBUTING.md
+    about: Standards for interaction in CDSL repositories.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: A net-new capability or enhancement.
+title: "[feature] "
+labels: ["feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should the new capability look like?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you evaluate, and why this one?
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - minor — small enhancement
+        - major — significant new capability

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,17 @@
+name: Question / discussion
+description: Open question, proposal, or research topic.
+title: "[question] "
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Be specific about what you're asking.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What have you already checked? Any prior issues?

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,33 @@
+name: Security issue
+description: CVE, auth issue, credential exposure, or other security defect.
+title: "[security] "
+labels: ["security", "major"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **⚠️ Sensitive issues:** if this involves a credential, exploit, or active attack vector,
+        email gasyoun@gmail.com directly instead of filing publicly.
+  - type: textarea
+    id: what
+    attributes:
+      label: What is the vulnerability?
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who is affected? What's the attack vector?
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - minor — disclosure-level, low impact
+        - major — exploitable, affects multiple users
+        - critical — active exploit, data/auth compromise
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,0 +1,24 @@
+name: Tech debt
+description: Refactoring, cleanup, dependency updates.
+title: "[tech-debt] "
+labels: ["tech-debt"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs cleanup?
+      description: Code area, dependency, or pattern to address.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now?
+      description: What pain or risk is this causing?
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed approach
+      description: How would you tackle it? (optional)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description
+Brief description of what this PR changes and why.
+
+## Type of change
+- [ ] Bug fix (non-breaking change fixing an issue)
+- [ ] New feature (non-breaking change adding functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional change)
+
+## Related issues
+Closes #(issue number)
+
+## Testing
+- [ ] Tested locally
+- [ ] Existing tests pass
+- [ ] New tests added (if applicable)
+
+## Checklist
+- [ ] Code follows the project style guidelines
+- [ ] Comments added for complex logic
+- [ ] Documentation updated (if needed)
+- [ ] No new warnings generated
+- [ ] Commit message(s) are clear and concise

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'python'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ app.*.map.json
 # Never commit these to csl-app; they live at:
 # https://github.com/sanskrit-lexicon/csl-sqlite/releases/latest
 assets/sqlite/*.sqlite
+
+# audit sidecars
+.contributing_old.md
+.contributing_audit.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.10
+    hooks:
+      - id: ruff
+        args: [--select=E9,F63,F7,F8]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.0] - 2026-06-13
+
+### Changed
+- Released the current changelog state as version 1.
+
 ## [0.2.2] - 2026-05-02
 
 ### Added
@@ -41,8 +46,6 @@ All notable changes to this project will be documented in this file.
 - **Engish Dictionaries Headwords**: Fixed wrong transliteration of English dictionary headwords to Devanagari and other schemes. See #20.
 - **UI updates**: Mainly visual changes. See #18, #21.
 
-
-
 ## [0.1.6] - 2026-03-25
 
 ### Added
@@ -66,13 +69,11 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - **Definition Search Transliteration**: Fixed issue where highlighted search terms in definitions were not transliterated when using Devanagari or other output scripts.
 
-
 ## [0.1.3] - 2026-03-24
 
 ### Added
 - **Cologne Theme**: Your favourite colour theme from Colgne website.
 - **Custom Themes**: Choose your colours. Make it your own.
-
 
 ## [0.1.2] - 2026-03-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ flutter build windows --release
 flutter build web --release
 
 # Regenerate app icons
-flutter pub run flutter_launcher_icons:main
+dart run flutter_launcher_icons
 ```
 
 Lint config is in `analysis_options.yaml` (uses `flutter_lints`; `print` statements are allowed).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at gasyoun@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to csl-app
+
+csl-app is a tooling repository in the [Sanskrit Lexicon](https://github.com/sanskrit-lexicon) project.
+
+> Inherits the [Sanskrit Lexicon org-wide contribution standard](https://github.com/sanskrit-lexicon/COLOGNE/blob/master/CONTRIBUTING.md). This file documents anything **repo-specific** on top of it.
+
+## Issue taxonomy
+
+This repo uses the **Cologne tooling-repo taxonomy** (not the dictionary taxonomy). Each issue gets one type, one severity, one milestone — labels are defined in [COLOGNE/CONTRIBUTING.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/master/CONTRIBUTING.md#issue-taxonomy--tooling-repos).
+
+## Pull requests
+
+1. Fork, branch, PR (link the issue in title or body).
+2. Match existing code style; see [`CLAUDE.md`](CLAUDE.md) for build commands and conventions.
+3. PR checklist:
+   - [ ] Tested locally
+   - [ ] Documentation updated where behaviour changes
+   - [ ] No breaking changes (or clearly flagged)

--- a/lib/core/transliteration_service.dart
+++ b/lib/core/transliteration_service.dart
@@ -77,8 +77,9 @@ class TransliterationService {
       return text;
     }
 
+    final String input = useAccented ? text : stripSLP1Accents(text);
     String out =
-        transliterate(text, useAccented ? 'slp1_accented' : 'slp1', toScheme);
+        transliterate(input, useAccented ? 'slp1_accented' : 'slp1', toScheme);
 
     // Fallback: if accents are requested for Devanagari but ASCII markers remained,
     // manually replace them with Vedic Unicode characters.
@@ -104,7 +105,7 @@ class TransliterationService {
   /// In key2, '/' appears before an accented vowel (Vedic pitch accent).
   /// Strip them when accent display is off, or when building LIKE queries.
   static String stripSLP1Accents(String slp1Text) =>
-      slp1Text.replaceAll('/', '').replaceAll('\\', '');
+      slp1Text.replaceAll('/', '').replaceAll('\\', '').replaceAll('^', '');
 
   /// Display name for a scheme code.
   static String displayName(String scheme) =>


### PR DESCRIPTION
Fixes #38.

## Root cause

`fromSlp1()` used the `'slp1'` source scheme when `useAccented=false`, but input text from the DB may contain SLP1 accent markers (`/`, `\`, `^`). These are not valid SLP1 phonemes — the transliterator passes them through as literal characters, producing visible slashes in Bengali, Devanagari, and other Indic-script outputs.

## Fix

- Strip accent markers via `stripSLP1Accents()` **before** transliterating when `useAccented=false`.
- Extend `stripSLP1Accents` to also strip `^` (svarita), which was previously missed alongside `/` and `\`.

## Changed file

[`lib/core/transliteration_service.dart`](https://github.com/sanskrit-lexicon/csl-app/blob/fix/accent-toggle-slashes/lib/core/transliteration_service.dart) — 3 lines changed.