### PR TITLE
Add og:image + Twitter card to the web app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,6 +25,17 @@
   <meta property="og:title" content="Cologne Sanskrit Lexicon">
   <meta property="og:description" content="Free offline Sanskrit dictionary. Search 49 dictionaries in your browser — no install required.">
   <meta property="og:type" content="website">
+  <meta property="og:url" content="https://sanskrit-lexicon.github.io/csl-app/">
+  <meta property="og:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Cologne Digital Sanskrit Lexicon">
+
+  <!-- Twitter card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cologne Sanskrit Lexicon">
+  <meta name="twitter:description" content="Free offline Sanskrit dictionary. Search 49 dictionaries in your browser — no install required.">
+  <meta name="twitter:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
The Flutter [`web/index.html`](https://github.com/sanskrit-lexicon/csl-app/blob/codex/og-image-social-card/web/index.html) already had `og:title`/`og:description` but **no image**, so link shares (Slack/Discord/Twitter/Facebook/LinkedIn) rendered no card.

Adds `og:image` + `og:url` and a Twitter `summary_large_image` card pointing at the shared CDSL social card hosted at the org root: `https://sanskrit-lexicon.github.io/cdsl-card.png` (already live). CI (`deploy.yml`) rebuilds `build/web` → gh-pages, so no generated files are touched here.

Part of an org-wide pass giving every `github.io` site a working social card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)