### PR TITLE
fix: strip SLP1 accent markers when Vedic Accents is off (re-apply of #47)

### DIFF
--- a/lib/core/transliteration_service.dart
+++ b/lib/core/transliteration_service.dart
@@ -77,8 +77,9 @@ class TransliterationService {
       return text;
     }
 
+    final String input = useAccented ? text : stripSLP1Accents(text);
     String out =
-        transliterate(text, useAccented ? 'slp1_accented' : 'slp1', toScheme);
+        transliterate(input, useAccented ? 'slp1_accented' : 'slp1', toScheme);
 
     // Fallback: if accents are requested for Devanagari but ASCII markers remained,
     // manually replace them with Vedic Unicode characters.
@@ -104,7 +105,7 @@ class TransliterationService {
   /// In key2, '/' appears before an accented vowel (Vedic pitch accent).
   /// Strip them when accent display is off, or when building LIKE queries.
   static String stripSLP1Accents(String slp1Text) =>
-      slp1Text.replaceAll('/', '').replaceAll('\\', '');
+      slp1Text.replaceAll('/', '').replaceAll('\\', '').replaceAll('^', '');
 
   /// Display name for a scheme code.
   static String displayName(String scheme) =>


### PR DESCRIPTION
Source-only re-apply of #47 via /branch-contention-recover: the original branch bundled 17 unrelated infra/template files that went CONFLICTING against main; the actual fix is this one file. Pre-strips `/`, `\`, `^` from SLP1 input when accents are toggled off so raw markers never reach the display (fixes #38). Supersedes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)