### PR TITLE
Resolve stale merge-conflict marker on PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,0 +1,18 @@
+# Project Objective: csl-app project
+
+## ➡️ Next Steps (Queue)
+
+- [ ] (no items queued)
+
+## 🚧 Current Work-In-Progress (WIP)
+
+- [ ] (no active task)
+
+## 🧠 Dev Notes & Hypotheses
+
+<!-- Persistent bugs, architectural pivots, things future-you needs to know. Keep dated. -->
+
+## ✅ Completed (Recent only)
+
+<!-- Mark completed milestones here. -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## PR Type
+- [ ] data
+- [ ] build
+- [ ] docs
+- [ ] navigation
+
+## Summary
+- What changed:
+- Why this change exists:
+
+## Test Surface
+- Automated checks:
+- Manual checks:
+- Pure helpers / decision points covered:
+- If build-related: import-safe verified? yes / no / n/a
+
+## Invariants
+- Must stay true:
+- Counts / alignment / join rules:
+- Source-of-truth assumptions:
+- What would count as regression:
+
+## Safety
+- Fallback / failure mode:
+- Observable marker or sanity check:
+- Rebuild / validate / verify command:
+
+## Reader-Facing Done
+- Navigation / entry point updated:
+- Docs / changelog / handoff updated:
+- Known limits or caveats exposed:
+- If not applicable, say why:
+
+## Type-Specific Notes
+- If `data`: schema/FK/PK checks, row-count expectations, epistemic limits
+- If `build`: side effects on import, generated artifact scope, rollback path
+- If `docs`: stale wording removed, authoritative docs confirmed
+- If `navigation`: links tested, discoverability improved in 1-2 clicks


### PR DESCRIPTION
## Summary
- A `/dirty-tree-sweep` run found this repo sitting on `main` with `.github/PULL_REQUEST_TEMPLATE.md` marked `DU` (deleted-by-us/unmerged) in the index, with no active `MERGE_HEAD` — a stale conflict marker from an earlier, never-completed merge, unrelated to the already-committed merge #37.
- Inspected the conflict stages: base = simple generic template, ours = deleted, theirs = the app-style template (PR Type/Summary/Test Surface/Invariants/Safety/Reader-Facing Done/Type-Specific Notes).
- The working-tree content is byte-identical to `ORS-FAQ`'s `.github/PULL_REQUEST_TEMPLATE.md`, confirming it's the intentional org app-style template, not merge debris — resolved by keeping the file (`git add`).
- Also tracked the previously-untracked `.ai_state.md` (same org-wide gap found in ~20 other dict repos by the sweep).

Ref: [H177](https://github.com/gasyoun/Uprava/blob/main/handoffs/H177-Sonnet_csl-app_pr_template_merge_conflict_04.07.26.md)

## Test plan
- [x] `git status` shows a clean tree after resolution
- [x] Confirmed template content matches the deployed org standard (`ORS-FAQ`)