### PR TITLE
docs: metadoc template v2 backfill (H663)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,29 +9,34 @@ is a Flutter app that packages the CDSL dictionaries for Android, iOS,
 macOS, Linux, Windows, and web from one Dart codebase, so lookup keeps
 working with no connection and no per-query server round-trip.
 
+The web build is deployed to GitHub Pages at
+[sanskrit-lexicon.github.io/csl-app](https://sanskrit-lexicon.github.io/csl-app/)
+(published from the `gh-pages` branch by
+[.github/workflows/deploy.yml](https://github.com/sanskrit-lexicon/csl-app/blob/main/.github/workflows/deploy.yml)).
+
 ## Structure
 
 | Path | Role |
 |---|---|
-| [lib/main.dart](lib/main.dart) | App entry point |
-| [lib/core/](lib/core) | Shared core logic |
-| [lib/features/](lib/features) | Feature modules |
-| [lib/models/](lib/models) | Data models |
-| [lib/providers/](lib/providers) | State management |
-| [lib/rendering/](lib/rendering) | Entry rendering |
-| [lib/db_init_io.dart](lib/db_init_io.dart) / [lib/db_init_web.dart](lib/db_init_web.dart) / [lib/db_init_stub.dart](lib/db_init_stub.dart) | Platform-specific DB bootstrap (native / web / fallback) — the offline-first design surfaces directly in the file layout |
-| [android/](android), [ios/](ios), [macos/](macos), [linux/](linux), [windows/](windows), [web/](web) | Per-platform Flutter shells |
-| [test/](test) | Test suite |
-| [scripts/](scripts) | Build/support scripts |
-| [reference/](reference) | Reference material |
-| [docs/BUILD_RELEASE_MANUAL.md](docs/BUILD_RELEASE_MANUAL.md) | **Operator manual**: per-platform build/run/release, Android signing, the automatic web deploy, and where the dictionary SQLites come from (csl-sqlite gh-pages, downloaded at runtime — nothing bundled) |
+| [lib/main.dart](https://github.com/sanskrit-lexicon/csl-app/blob/main/lib/main.dart) | App entry point |
+| [lib/core/](https://github.com/sanskrit-lexicon/csl-app/tree/main/lib/core) | Shared core logic |
+| [lib/features/](https://github.com/sanskrit-lexicon/csl-app/tree/main/lib/features) | Feature modules |
+| [lib/models/](https://github.com/sanskrit-lexicon/csl-app/tree/main/lib/models) | Data models |
+| [lib/providers/](https://github.com/sanskrit-lexicon/csl-app/tree/main/lib/providers) | State management |
+| [lib/rendering/](https://github.com/sanskrit-lexicon/csl-app/tree/main/lib/rendering) | Entry rendering |
+| [lib/db_init_io.dart](https://github.com/sanskrit-lexicon/csl-app/blob/main/lib/db_init_io.dart) / [lib/db_init_web.dart](https://github.com/sanskrit-lexicon/csl-app/blob/main/lib/db_init_web.dart) / [lib/db_init_stub.dart](https://github.com/sanskrit-lexicon/csl-app/blob/main/lib/db_init_stub.dart) | Platform-specific DB bootstrap (native / web / fallback) — the offline-first design surfaces directly in the file layout |
+| [android/](https://github.com/sanskrit-lexicon/csl-app/tree/main/android), [ios/](https://github.com/sanskrit-lexicon/csl-app/tree/main/ios), [macos/](https://github.com/sanskrit-lexicon/csl-app/tree/main/macos), [linux/](https://github.com/sanskrit-lexicon/csl-app/tree/main/linux), [windows/](https://github.com/sanskrit-lexicon/csl-app/tree/main/windows), [web/](https://github.com/sanskrit-lexicon/csl-app/tree/main/web) | Per-platform Flutter shells |
+| [test/](https://github.com/sanskrit-lexicon/csl-app/tree/main/test) | Test suite |
+| [scripts/](https://github.com/sanskrit-lexicon/csl-app/tree/main/scripts) | Build/support scripts |
+| [reference/](https://github.com/sanskrit-lexicon/csl-app/tree/main/reference) | Reference material |
+| [docs/BUILD_RELEASE_MANUAL.md](https://github.com/sanskrit-lexicon/csl-app/blob/main/docs/BUILD_RELEASE_MANUAL.md) | **Operator manual**: per-platform build/run/release, Android signing, the automatic web deploy, and where the dictionary SQLites come from (csl-sqlite gh-pages, downloaded at runtime — nothing bundled) |
 
 ## Usage example — illustrative, not executed
 
 This is a Flutter mobile/desktop app; running it needs the Flutter SDK and a
 target device/emulator, which this session doesn't have. The real, standard
 build/run commands for this exact package (read from
-[pubspec.yaml](pubspec.yaml), not invented) are:
+[pubspec.yaml](https://github.com/sanskrit-lexicon/csl-app/blob/main/pubspec.yaml), not invented) are:
 
 ```bash
 flutter pub get
@@ -45,30 +50,24 @@ flutter build apk          # or: build ios / build macos / build linux / build w
 ```
 name: cologne_sanskrit_lexicon
 description: Cologne Sanskrit Lexicon - offline dictionary app for the Cologne Digital Sanskrit Dictionaries.
+version: 0.2.3+11
 ```
 
 ## Issues overview
 
-Snapshot 2026-05-29: **3** open, **36** closed.
-
-| Milestone | Open | Closed | Total |
-|---|---:|---:|---:|
-| User Experience | 2 | 0 | 2 |
-| Developer Experience | 1 | 0 | 1 |
-
-Open by type: enhancement 1 · documentation 1 · bug 1. By severity: minor 2 · trivial 1.
+Snapshot 2026-07-11: **0** open, **39** closed.
 
 ## GitHub issue conventions
 
 Follows the [Cologne tooling-repo taxonomy](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md):
 
-- **17 type labels** across 5 categories
-- **4 severity levels**: trivial, minor, major, critical
+- **9 type labels**: `bug`, `feature`, `enhancement`, `performance`, `tech-debt`, `security`, `documentation`, `infrastructure`, `question`
+- **4 severity levels**: `trivial`, `minor`, `major`, `critical`
 - **5 milestones**: API Stability, User Experience, Data Quality, Developer Experience, Community
-- **Domain labels** scoped to web-frontend: `domain:ui`, `domain:routing`, `domain:i18n`, `domain:rendering`
+- **Domain labels** scoped to the web-frontend: `domain:ui`, `domain:routing`, `domain:i18n`, `domain:rendering`
 - **Org Project**: [Tooling Roadmap](https://github.com/orgs/sanskrit-lexicon/projects/9)
 
-See [CLAUDE.md](CLAUDE.md) for full definitions.
+See [CLAUDE.md](https://github.com/sanskrit-lexicon/csl-app/blob/main/CLAUDE.md) for full definitions.
 
 ---
 

--- a/docs/BUILD_RELEASE_MANUAL.meta.md
+++ b/docs/BUILD_RELEASE_MANUAL.meta.md
@@ -48,6 +48,51 @@ live csl-sqlite gh-pages listing — none invented.
   csl-sqlite gh-pages) is out of scope here — it belongs to the upstream
   pipeline's docs.
 
+## Intended use / known misuse
+
+**For:** a maintainer or contributor executing an actual build/release/debug
+step on `csl-app` — copy-pasting a command, checking a platform-specific
+signing requirement, or tracing why a dictionary download failed. It is a
+day-to-day operator reference, not an architecture explainer.
+
+**Known/likely misuse:**
+- Reading it as documentation of the Cologne-side pipeline that produces
+  `{code}.sqlite` files — that pipeline is explicitly out of scope (see
+  "Known limitations" below) and lives in the upstream CDSL repos, not here.
+- Treating the iOS/macOS signing section as a verified, project-specific
+  runbook — it is generic Flutter guidance, untested against a real App
+  Store submission, and should not be followed blind for a production iOS
+  release.
+- Using it as a substitute for
+  [reference/public.md](https://github.com/sanskrit-lexicon/csl-app/blob/main/reference/public.md) /
+  [reference/private.md](https://github.com/sanskrit-lexicon/csl-app/blob/main/reference/private.md)
+  when the question is "what does this API method do" rather than "how do I
+  build/ship" — the manual covers process, not the full API surface.
+- Assuming any dictionary database ships inside the app binary — it never
+  does; every dictionary is downloaded at runtime (§2 of the subject
+  document), so the manual's build steps alone never produce an app with
+  data preloaded.
+
+## Maintenance & sunset plan
+
+The subject document is maintained by whoever next changes the build/release
+surface it documents — CI workflow edits
+([.github/workflows/deploy.yml](https://github.com/sanskrit-lexicon/csl-app/blob/main/.github/workflows/deploy.yml)),
+`pubspec.yaml` platform/version bumps, or changes to the download pipeline
+(`lib/core/download_service.dart`, `lib/core/database_helper.dart`) should
+update the manual in the same PR. There is no dedicated owner beyond the
+`csl-app` maintainers collectively; the backlog item "scripted release
+ritual" (item 5 above) is the closest thing to a planned automation owner.
+"Archived/ended" for this document means: `csl-app` itself is retired or
+replaced by a different client, or the build/release process it describes
+is superseded by a different manual — at that point this file moves to
+`docs/archive/` (matching the org's handoff-archive convention) with a
+pointer left in its place, rather than being deleted.
+
+## Deprecation status
+
+`active`
+
 ## Related documents
 
 - [README.md](https://github.com/sanskrit-lexicon/csl-app/blob/main/README.md) — repo overview + structure table
@@ -60,6 +105,7 @@ live csl-sqlite gh-pages listing — none invented.
 | Date | Change | By |
 |---|---|---|
 | 11-07-2026 | Initial version (H504) | Fable 5 (`claude-fable-5`) |
+| 11-07-2026 | template v2 backfill (H663) | Sonnet 5 (`claude-sonnet-5`) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Backfill docs/BUILD_RELEASE_MANUAL.meta.md with the template-v2 sections (H663): Intended use / known misuse, Maintenance & sunset plan, Deprecation status.
- Append revision-history row for this backfill.

## Test plan
- [x] Content reviewed against subject doc (docs/BUILD_RELEASE_MANUAL.md) for accuracy
- [x] Full blob URLs used for all links

🤖 Generated with [Claude Code](https://claude.com/claude-code)